### PR TITLE
Replace realtime.library 'Player' with regular timer.devic wait

### DIFF
--- a/src/driver_camd_midi.h
+++ b/src/driver_camd_midi.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2009 Jonathon Fowler <jf@jonof.id.au>
+ Copyright (C) 2021 Mathias Heyer <sonode@gmx.de>
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This is functioning, but I am not sure if it really makes a difference.
Please test on  real hardware.

Using a player for pacing the midi task seems overkill. There's only one
timer that is needed and the realtime.library's TICK_FREQ is barely
precise enough. timer.device offers higher precision anbd may come with
less overhead.
Since the wait period 'wiatTics' basically assumes that no wallclock time
has passed since the last tick, adjust it by the amount of time it took to
service the midi routine.